### PR TITLE
Support multiple Android NDKs

### DIFF
--- a/mozconfigs/compile-environment
+++ b/mozconfigs/compile-environment
@@ -1,5 +1,5 @@
 if [ -z $ARTIFACT_BUILD ] && [ ! -z $ANDROID_BUILD ]; then
-  ANDROID_NDK_DIR=$(ls $MOZBUILD | grep '^android-ndk-')
+  ANDROID_NDK_DIR=$(ls -r $MOZBUILD | grep '^android-ndk-' | head -n 1)
   ac_add_options --with-android-ndk=$MOZBUILD/$ANDROID_NDK_DIR
 fi
 


### PR DESCRIPTION
Today, you can have multiple NDKs installed:

```
$ ls ~/.mozbuild/ | grep '^android-ndk-'
android-ndk-r21d
android-ndk-r23c
android-ndk-r26c
android-ndk-r27
android-ndk-r27b
android-ndk-r27c
android-ndk-r28
android-ndk-r28b
```

If thats the case, then we need to pick the latest version typically, assuming there were no backouts after you bootstrap.

This patch assumes that your ls is returning an ordered list of NDKs in ascending order which is what I seem to have on my MacOS workstation.